### PR TITLE
7.0 Make the partner on 2 lines maximum with ellipsis (webkit only)

### DIFF
--- a/account_banking_reconciliation/report/detailed_reconciliation.mako
+++ b/account_banking_reconciliation/report/detailed_reconciliation.mako
@@ -37,11 +37,25 @@
       width:100px;
       }
       .col_partner {
+          /*
+          Max of 2 lines in height
+          */
+          line-height: 15px;
+          max-height: 30px;
           width:150px;
           text-overflow: ellipsis;
           overflow: hidden;
-          white-space: nowrap;
       }
+
+      div.col_partner {
+        display: -webkit-box;
+        /*
+        Enable ellipsis on webkit browser for 2 lines
+        */
+        -webkit-box-orient: vertical;
+        -webkit-line-clamp: 2;
+      }
+
       .right_col {
       text-align:right;
       width:100px;


### PR DESCRIPTION
Force the partner name to be on maximum two lines and show ellipsis... Currently using webkit version of css styles but could be updated once support will be available in newer versions.
